### PR TITLE
mentoring announcement tweet ?

### DIFF
--- a/tweets/unconference_mentoring.tweet
+++ b/tweets/unconference_mentoring.tweet
@@ -1,1 +1,1 @@
-Join us on Thursday June 24th at 13 CEST on Zoom (sign up for the unconference (https://nordic-rse.org/events/2021-online-unconference) for zoom details) for an informal mentoring chat to finalize or even initialize your contribution to #NordicRSE unconference next week #RSEng
+Join us on Thursday June 24th at 13 CEST for an informal mentoring chat to finalize or even initialize your contribution to #NordicRSE unconference next week #RSEng (register for the unconference for connection details): https://nordic-rse.org/events/2021-online-unconference

--- a/tweets/unconference_mentoring.tweet
+++ b/tweets/unconference_mentoring.tweet
@@ -1,0 +1,1 @@
+Join us on Thursday June 24th at 13 CEST for an informal mentoring chat to finalize or even initialize your contribution to #NordicRSE unconference next week #RSEng

--- a/tweets/unconference_mentoring.tweet
+++ b/tweets/unconference_mentoring.tweet
@@ -1,1 +1,1 @@
-Join us on Thursday June 24th at 13 CEST for an informal mentoring chat to finalize or even initialize your contribution to #NordicRSE unconference next week #RSEng
+Join us on Thursday June 24th at 13 CEST on Zoom (sign up for the unconference (https://nordic-rse.org/events/2021-online-unconference) for zoom details) for an informal mentoring chat to finalize or even initialize your contribution to #NordicRSE unconference next week #RSEng


### PR DESCRIPTION
Do we also want to invite people that have not yet submitted anything to the mentoring chat?
Then we could post something like this?
But we would need to add a place or add how interested people can be informed about the place? -> this is why it is a draft, some information still needs to be added
Eg tell them to sign up before thursday then they will get an email with the connection details?

If we want to announce this, it should be tweeted maybe wednesday morning to give some time to think and sign up?

Feel free to also change full text, this is just a quick suggestion to get the ball rolling.